### PR TITLE
Fix AttributeError in GPUIterator

### DIFF
--- a/src/gradient_mechanics/data/gpu_iterator.py
+++ b/src/gradient_mechanics/data/gpu_iterator.py
@@ -64,7 +64,8 @@ class GPUIterator:
                 if stop_iteration:
                     raise StopIteration
                 else:
-                    self.submit_next()
+                    # prefetch the next batch when no futures are available to avoid stalls
+                    self._submit_next()
 
             future = self.futures.popleft()
             try:


### PR DESCRIPTION
## Summary
- fix incorrect method call in `GPUIterator.__next__`
- explain why prefetching occurs when the queue is empty

## Testing
- `pytest -q` *(fails: pyenv version 'cpython-3.10' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850afca0a648333ae8ba61dd1311cbd