### PR TITLE
Upgrade to Python 3.11 and PyNvVideoCodec 2

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,1 @@
-cpython-3.10
+cpython-3.11

--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ Create and sync the development environment using
 
 ```sh
 uv venv
+source .venv/bin/activate
 uv sync
 ```
 
 Run the tests to make sure everything is set up correctly:
 
 ```sh
-uv run pytest
+pytest
 ```
 
 ## Benchmarks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,15 @@ name = "gradient-mechanics"
 version = "0.0.4"
 description = "Accelerated deep learning."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "cvcuda-cu12>=0.14.0",
     "numpy>=1.26.0",
     "nvidia-nvimgcodec-cu12>=0.5.0.13",
-    "pyav>=13.1.0",
+    "av>=13.1.0",
     "pynvvideocodec>=1.0.2",
     "torch>=2.0.1",
+    "pycuda>=2025.1.1",
 ]
 
 [build-system]

--- a/src/gradient_mechanics/data/transforms.py
+++ b/src/gradient_mechanics/data/transforms.py
@@ -25,7 +25,7 @@ class Transform:
         """
         self.device_id = device_id
         self.device = torch.device("cuda", device_id)
-        self.stream = stream or 0
+        self.stream = stream if stream else 0
         self.input_types: Set[Any] = set()
 
     def register_input_type(self, input_type: type) -> None:
@@ -35,7 +35,8 @@ class Transform:
     def __call__(self, batch: List[Any]) -> List[cvcuda.Tensor]:
         """Apply the transform to a list of registered data types."""
         try:
-            transformed = _apply_recursive(self.transform, batch, self.input_types)
+            with self.device:
+                transformed = _apply_recursive(self.transform, batch, self.input_types)
         except Exception as e:
             print(
                 f"Exception was raised during the processing of transform '{self.__class__.__name__}'. This could be caused by input data not conforming to what is expected of container types.",


### PR DESCRIPTION
- New PyNvVideoCodec errors without explicit cuda context handling
- pyav package name was incorrectly specified
- Video decoding was ignoring passed in cuda stream